### PR TITLE
Correct the name of the github repo in docs/make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ makedocs(
 )
 
 deploydocs(
-    repo="github.com/NREL-SIENNA/PRASInterface.git",
+    repo="github.com/NREL-SIENNA/PRASInterface.jl.git",
     target="build",
     branch="gh-pages",
     devbranch="main",


### PR DESCRIPTION
I didn't notice this bug before, but deploy to main fails to actually publish the docs since it looks at `ENV` and sees we're NREL-Sienna/PRASInterface.jl and not NREL-Sienna/PRASInterface.jl

Note this issue is impossible to test without merging really.